### PR TITLE
docs: adicionar guia de uso das labels no projeto

### DIFF
--- a/GUIA_DE_LABELS.md
+++ b/GUIA_DE_LABELS.md
@@ -1,0 +1,42 @@
+## 🏷️ Sistema de Labels para Organização das Issues e Pull Requests
+
+Para facilitar a colaboração e manter o projeto bem organizado, implementamos um **sistema de labels padronizado** para categorizar e priorizar tarefas, bugs, melhorias e discussões.
+
+### ✅ O que foi implementado
+
+- Labels organizadas por **tipo de tarefa**, **prioridade**, **status** e **outros contextos** úteis para a comunidade.
+- Cada label possui uma **cor específica** e uma **descrição clara** para facilitar o entendimento.
+- Objetivo: tornar a colaboração mais fluida, dar visibilidade ao que precisa de atenção e guiar novos colaboradores.
+
+---
+
+### 🧭 Como usar as labels
+
+#### Ao abrir uma **issue**:
+1. Escolha o tipo apropriado: `feature`, `bug`, `documentation`, `refactor`, etc.
+2. Defina a prioridade: `priority: alta`, `priority: média`, ou `priority: baixa`.
+3. Se for iniciante, procure por `good first issue`.
+4. Use `help wanted` se precisar de apoio da comunidade.
+
+#### Ao criar um **Pull Request**:
+1. Marque como `em andamento` durante o desenvolvimento.
+2. Altere para `aguardando review` ao finalizar a primeira versão.
+3. A label `concluído` será usada pelos mantenedores após aprovação e merge.
+
+---
+
+### 🧪 Exemplo prático
+
+- Está corrigindo um bug urgente?  
+  Use: `bug` + `priority: alta` + `em andamento`.
+
+- Vai propor uma nova funcionalidade?  
+  Use: `feature` + `priority: média` + `help wanted` (caso queira ajuda).
+
+---
+
+### 🙌 Colabore!
+
+Se tiver sugestões de novas labels ou melhorias nesse sistema, fique à vontade para abrir uma issue com a label `discussion`.
+
+Juntos, vamos manter este projeto colaborativo, acessível e bem documentado! 🚀


### PR DESCRIPTION
Adicionado o arquivo LABELS_GUIDE.md com orientações sobre o uso das labels nas issues e pull requests.  O objetivo é padronizar a organização e facilitar a colaboração da comunidade no repositório.