### PR TITLE
Fix unused prop in registration form

### DIFF
--- a/src/app/events/register/page.tsx
+++ b/src/app/events/register/page.tsx
@@ -140,7 +140,6 @@ function EventRegisterContent() {
               <>
                 <h2 className="text-2xl font-bold mb-4 text-black">Inscreva-se neste evento</h2>
                 <RegistrationForm
-                  eventId={eventId}
                   onSubmit={handleRegister}
                   isSubmitting={isSubmitting}
                 />

--- a/src/components/events/RegistrationForm.tsx
+++ b/src/components/events/RegistrationForm.tsx
@@ -9,12 +9,11 @@ import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
 
 interface RegistrationFormProps {
-  eventId: string;
   onSubmit: (data: EventRegistrationFormData) => void;
   isSubmitting: boolean;
 }
 
-export function RegistrationForm({ eventId, onSubmit, isSubmitting }: RegistrationFormProps) {
+export function RegistrationForm({ onSubmit, isSubmitting }: RegistrationFormProps) {
   const {
     register,
     handleSubmit,


### PR DESCRIPTION
## Summary
- remove unused eventId prop from RegistrationForm component
- update register page to stop passing the deleted prop

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841f55049a8832bb07bd2e2e970e31f