### PR TITLE
Add CD workflow and cache CI dependencies

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,34 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📅 Checkout do repositório
+        uses: actions/checkout@v3
+
+      - name: 🛠 Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - name: 📦 Instalar dependências
+        run: npm ci
+
+      - name: 🔧 Build do projeto
+        run: npm run build
+
+      - name: ✨ Deploy para o Vercel
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: npx vercel deploy --prod --confirm --token $VERCEL_TOKEN

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,14 @@ jobs:
         with:
           node-version: 18
 
+      - name: ⬇️ Cache de dependências
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
       - name: 📦 Instalar dependências
         run: npm ci
 
@@ -31,6 +39,7 @@ jobs:
       - name: 🛠️ Build do projeto
         run: npm run build
 
-      # - name: 🧪 Testes (se houver)
-      #   run: npm run test
+      - name: 🧪 Testes (se houver)
+        if: ${{ hashFiles('**/*.test.{js,jsx,ts,tsx}') != '' }}
+        run: npm run test --if-present
 

--- a/README.md
+++ b/README.md
@@ -299,6 +299,25 @@ Este projeto está sob a licença MIT. Veja o arquivo [LICENSE](LICENSE) para ma
 - **Backend**: Firebase e integração com APIs REST
 - **DevOps**: Deploy automatizado e CI/CD
 
+## ⚙️ CI/CD
+
+O repositório possui dois fluxos de trabalho no GitHub Actions:
+
+- **CI** (`.github/workflows/ci.yml`): executado em todo *push* ou *pull request* para `main`. Utiliza cache de dependências, realiza checagem de tipos, lint e build. Se houver arquivos de teste (`*.test.ts` ou `*.test.tsx`), executa `npm run test`.
+- **CD** (`.github/workflows/cd.yml`): disparado quando há *push* na branch `main` ou tags no formato `v*`. Constrói o projeto e faz o deploy no Vercel.
+
+Para que o deploy funcione é necessário configurar os segredos `VERCEL_TOKEN`, `VERCEL_ORG_ID` e `VERCEL_PROJECT_ID` nas configurações do repositório.
+
+### Executando localmente
+
+```bash
+npm ci
+npm run lint
+npm run type-check
+npm run build
+npm test # se houver testes
+```
+
 ## 🚀 Contribuidores
 
 Agradecemos a todos os desenvolvedores que contribuíram para tornar o TechEVentos uma realidade:


### PR DESCRIPTION
## Summary
- cache dependencies during CI
- run tests when present
- create CD workflow for Vercel deploys
- document CI/CD and local build instructions

## Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841fb0d6fd0832bbf8a0b4a589c3b92